### PR TITLE
Add win and lose music using SoundManager.play_music_random function

### DIFF
--- a/Scenes/main.gd
+++ b/Scenes/main.gd
@@ -123,6 +123,7 @@ func game_win() -> void:
 	remove_burned_letters_from_story()
 	win_screen._set_title_and_story(_title, _story)
 	win_screen.show()
+	SoundManager.play_music_random($BGMusic, "WIN")
 
 
 func game_over() -> void:
@@ -136,6 +137,7 @@ func game_over() -> void:
 	GameManager.PlayerScore = 0
 	GameManager.actual_level = 1
 	DataManager.save_game_data()
+	SoundManager.play_music_random($BGMusic, "LOSE")
 
 
 func make_explosion_and_shoot(pos: Vector2) -> void:

--- a/Singleton/SoundManager.gd
+++ b/Singleton/SoundManager.gd
@@ -29,6 +29,13 @@ preload("res://Assets/Sounds/start_screen/Lyric Fantasy Theme #3.ogg"),
 preload("res://Assets/Sounds/start_screen/Lyric Fantasy Theme #4.ogg")
 ]
 
+const WIN_SOUND = [
+preload("res://Assets/Sounds/win/win_music.ogg")
+]
+
+const LOSE_SOUND = [
+preload("res://Assets/Sounds/lose/lose_music.ogg")
+]
 
 func play_laser_random(audio: AudioStreamPlayer):
 	audio.stream = LASER_SOUND.pick_random()
@@ -41,4 +48,8 @@ func play_music_random(audio: AudioStreamPlayer, scene: String):
 			audio.stream = START_SOUND.pick_random()
 		"GAME":
 			audio.stream = GAME_SOUND.pick_random()
+		"WIN":
+			audio.stream = WIN_SOUND.pick_random()
+		"LOSE":
+			audio.stream = LOSE_SOUND.pick_random()
 	audio.play()


### PR DESCRIPTION
Add win and lose music functionality.

* Add `WIN_SOUND` and `LOSE_SOUND` constants to `SoundManager.gd` to preload win and lose music files.
* Modify `play_music_random` function in `SoundManager.gd` to handle "WIN" and "LOSE" scenes.
* Call `SoundManager.play_music_random` with "WIN" in `game_win` function in `main.gd`.
* Call `SoundManager.play_music_random` with "LOSE" in `game_over` function in `main.gd`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/markod0925/LetterCatcher/pull/4?shareId=387d2693-d617-415c-a750-bc7fad8c3dd0).