### PR TITLE
Fix balloon assets not shown in exported executables

### DIFF
--- a/Scenes/enemy/base_enemy.gd
+++ b/Scenes/enemy/base_enemy.gd
@@ -17,9 +17,7 @@ func _ready():
 	vpr = get_viewport_rect()
 	falling_speed = 0
 	baloon.hide()
-	var balloon_list = GameManager.list_balloon_files
-	var random_balloon = balloon_list[randi_range(0, balloon_list.size()-1)]
-	baloon.texture = load("res://Assets/Balloons/%s" % random_balloon)
+	baloon.texture = DataManager.pick_random_balloon()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Scenes/letter.gd
+++ b/Scenes/letter.gd
@@ -13,11 +13,9 @@ var _lower_case_level : bool = false
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	vpr = get_viewport_rect()
-	# Pick a random .png file from the list
+	# Pick a random preloaded texture from the list
 	baloon.hide()
-	var balloon_list = GameManager.list_balloon_files
-	var random_balloon = balloon_list[randi_range(0, balloon_list.size()-1)]
-	baloon.texture = load("res://Assets/Balloons/%s" % random_balloon)
+	baloon.texture = DataManager.pick_random_balloon()
 	_lower_case_level = GameManager.actual_level%2 == 0
 
 

--- a/Singleton/DataManager.gd
+++ b/Singleton/DataManager.gd
@@ -10,10 +10,22 @@ var high_score : Dictionary = {
 	str(GameManager.Difficulty.HARD) : 0,
 }
 
+const BALLOON_FILES = [
+	preload("res://Assets/Balloons/balloon_form_1_1.png"),
+	preload("res://Assets/Balloons/balloon_form_1_13.png"),
+	preload("res://Assets/Balloons/balloon_form_1_16.png"),
+	preload("res://Assets/Balloons/balloon_form_1_20.png"),
+	preload("res://Assets/Balloons/balloon_form_1_24.png"),
+	preload("res://Assets/Balloons/balloon_form_1_27.png"),
+	preload("res://Assets/Balloons/balloon_form_1_28.png"),
+	preload("res://Assets/Balloons/balloon_form_1_31.png"),
+	preload("res://Assets/Balloons/balloon_form_1_34.png"),
+	preload("res://Assets/Balloons/balloon_form_1_8.png")
+]
+
 func _ready():
 	load_game_data()
 	load_stories_data()
-
 
 func reset_game_data() -> void:
 	high_score = {
@@ -23,7 +35,6 @@ func reset_game_data() -> void:
 	}
 	save_game_data()
 
-
 func save_game_data() -> void:
 	var file = FileAccess.open(DATA_FILE, FileAccess.WRITE)
 	var data : Dictionary = {
@@ -31,7 +42,6 @@ func save_game_data() -> void:
 	}
 	data["HIGH_SCORE"] = high_score
 	file.store_string(JSON.stringify(data))
-
 
 func load_game_data() -> void:
 	if !FileAccess.file_exists(DATA_FILE):
@@ -48,7 +58,6 @@ func load_game_data() -> void:
 
 	if "HIGH_SCORE" in data:
 		high_score = data["HIGH_SCORE"]
-
 
 func load_stories_data() -> void:
 	if !FileAccess.file_exists(STORIES_FILE):
@@ -75,3 +84,9 @@ func load_stories_data() -> void:
 				data[lang_key].erase(diff_key)
 
 	stories_dict = data
+
+func get_balloon_files() -> Array:
+	return BALLOON_FILES
+
+func pick_random_balloon() -> String:
+	return BALLOON_FILES[randi_range(0, BALLOON_FILES.size() - 1)]

--- a/Singleton/DataManager.gd
+++ b/Singleton/DataManager.gd
@@ -85,8 +85,6 @@ func load_stories_data() -> void:
 
 	stories_dict = data
 
-func get_balloon_files() -> Array:
-	return BALLOON_FILES
 
-func pick_random_balloon() -> String:
+func pick_random_balloon() -> CompressedTexture2D:
 	return BALLOON_FILES[randi_range(0, BALLOON_FILES.size() - 1)]

--- a/Singleton/GameManager.gd
+++ b/Singleton/GameManager.gd
@@ -75,7 +75,7 @@ func get_story() -> Dictionary:
 func start_new_game() -> void:
 	PlayerScore = 0
 	actual_level = 1
-	list_balloon_files = list_balloons()
+	list_balloon_files = DataManager.get_balloon_files()
 	Boss_activated = false
 	load_main_scene()
 
@@ -106,19 +106,3 @@ func create_info_popup_scene(pos: Vector2, info: String) -> void:
 	var new_popup = POPUP_SCENE.instantiate()
 	new_popup.setup(pos, info)
 	call_add_child(new_popup)
-
-
-func list_balloons() -> Array:
-	var balloons = []
-	var dir = DirAccess.open("res://Assets/Balloons")
-	if dir:
-		dir.list_dir_begin()
-		var file_name = dir.get_next()
-		while file_name != "":
-			if !dir.current_is_dir() and file_name.ends_with(".png"):
-				balloons.append(file_name)
-			file_name = dir.get_next()
-		dir.list_dir_end()
-	else:
-		print("An error occurred when trying to access the path.")
-	return balloons

--- a/Singleton/GameManager.gd
+++ b/Singleton/GameManager.gd
@@ -5,7 +5,6 @@ const ERROR_CODE = "ErrA3Vcs5"
 var PlayerScore : int = 0
 var actual_level : int = 1
 var actual_difficulty : Difficulty = Difficulty.EASY
-var list_balloon_files : Array
 var POPUP_SCENE : PackedScene = preload("res://Scenes/popup/popup.tscn")
 var local_lang = "it"
 var Boss_activated : bool = false
@@ -75,7 +74,6 @@ func get_story() -> Dictionary:
 func start_new_game() -> void:
 	PlayerScore = 0
 	actual_level = 1
-	list_balloon_files = DataManager.get_balloon_files()
 	Boss_activated = false
 	load_main_scene()
 


### PR DESCRIPTION
Fixes #5

Hardcode balloon asset paths in `DataManager.gd` and update relevant functions to use preloaded textures.

* Add a constant `BALLOON_FILES` in `DataManager.gd` with a list of preloaded balloon textures.
* Add functions `get_balloon_files` and `pick_random_balloon` in `DataManager.gd` to return the list of preloaded textures and a random texture, respectively.
* Remove the `list_balloons` function from `GameManager.gd` and update the `start_new_game` function to call `DataManager.get_balloon_files`.
* Update the `_ready` function in `base_enemy.gd` and `letter.gd` to use the preloaded balloon textures from `DataManager.pick_random_balloon`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/markod0925/LetterCatcher/pull/6?shareId=69050ec9-95ea-4792-a032-ba52b9136067).